### PR TITLE
Python 3 port

### DIFF
--- a/geneagrapher/cache_grabber.py
+++ b/geneagrapher/cache_grabber.py
@@ -1,6 +1,6 @@
 import shelve
 from time import time
-from grabber import Grabber
+from .grabber import Grabber
 
 
 class CacheGrabber:

--- a/geneagrapher/geneagrapher.py
+++ b/geneagrapher/geneagrapher.py
@@ -174,13 +174,12 @@ geneacache]",
 
     def generate_dot_file(self):
         dotfile = self.graph.generate_dot_file(self.get_ancestors, self.get_descendants)
-        dotfile = dotfile.encode("utf-8", "replace")
         if self.write_filename is not None:
             outfile = open(self.write_filename, "w")
             outfile.write(dotfile)
             outfile.close()
         else:
-            print(dotfile, end=' ')
+            print(dotfile, end='')
 
 
 def ggrapher():

--- a/geneagrapher/geneagrapher.py
+++ b/geneagrapher/geneagrapher.py
@@ -2,9 +2,9 @@ from argparse import ArgumentParser
 from collections import deque
 import pkg_resources
 import sys
-from cache_grabber import CacheGrabber
-from graph import Graph
-from grabber import Grabber
+from .cache_grabber import CacheGrabber
+from .graph import Graph
+from .grabber import Grabber
 
 
 class Geneagrapher:
@@ -116,9 +116,9 @@ geneacache]",
                 record = grabber.get_record(id)
                 if self.verbose:
                     if "message" in record:
-                        print record["message"]
+                        print(record["message"])
                     else:
-                        print
+                        print()
                 self.graph.add_node(
                     record["name"],
                     record["institution"],
@@ -180,7 +180,7 @@ geneacache]",
             outfile.write(dotfile)
             outfile.close()
         else:
-            print dotfile,
+            print(dotfile, end=' ')
 
 
 def ggrapher():
@@ -192,7 +192,7 @@ def ggrapher():
     try:
         ggrapher.build_graph()
     except ValueError as e:
-        print e
+        print(e)
     ggrapher.generate_dot_file()
 
 

--- a/geneagrapher/grabber.py
+++ b/geneagrapher/grabber.py
@@ -1,4 +1,4 @@
-import urllib
+import urllib.request, urllib.parse, urllib.error
 import re
 from bs4 import BeautifulSoup
 
@@ -25,7 +25,7 @@ class Grabber:
         institution, and the year of the mathematician's degree.
         """
         url = "http://genealogy.math.ndsu.nodak.edu/id.php?id=" + str(id)
-        page = urllib.urlopen(url)
+        page = urllib.request.urlopen(url)
         soup = BeautifulSoup(page, "lxml")
         page.close()
 
@@ -58,7 +58,7 @@ def has_record(soup):
         return False
     return (
         not soup.p.string
-        == u"You have specified an ID that does \
+        == "You have specified an ID that does \
 not exist in the database. Please back up and try again."
     )
 
@@ -85,7 +85,7 @@ text-align: center; margin-bottom: 1ex",
             .find("span")
             .text
         )
-        if institution == u"":
+        if institution == "":
             institution = None
     except AttributeError:
         institution = None

--- a/geneagrapher/graph/__init__.py
+++ b/geneagrapher/graph/__init__.py
@@ -1,3 +1,3 @@
-from graph import DuplicateNodeError, Graph
-from node import Node
-from record import Record
+from .graph import DuplicateNodeError, Graph
+from .node import Node
+from .record import Record

--- a/geneagrapher/graph/graph.py
+++ b/geneagrapher/graph/graph.py
@@ -1,5 +1,5 @@
-from node import Node
-from record import Record
+from .node import Node
+from .record import Record
 
 
 class DuplicateNodeError(Exception):
@@ -64,7 +64,7 @@ of Node objects for 'seed_nodes'"
         """
         Return a list of the nodes in the graph.
         """
-        return self.keys()
+        return list(self.keys())
 
     def add_node(self, name, institution, year, id, advisors, advisees, is_seed=False):
         """
@@ -122,7 +122,7 @@ of Node objects for 'seed_nodes'"
         edges = ""
         dotfile = ""
 
-        dotfile += u"""digraph genealogy {
+        dotfile += """digraph genealogy {
     graph [charset="utf-8"];
     node [shape=plaintext];
     edge [style=bold];\n\n"""
@@ -161,7 +161,7 @@ of Node objects for 'seed_nodes'"
                 queue += sorted_descendants
 
             # Print this node's information.
-            nodestr = u'    {} [label="{}"];'.format(node_id, node)
+            nodestr = '    {} [label="{}"];'.format(node_id, node)
             dotfile += nodestr
 
             # Store the connection information for this node.

--- a/geneagrapher/graph/graph.py
+++ b/geneagrapher/graph/graph.py
@@ -64,7 +64,7 @@ of Node objects for 'seed_nodes'"
         """
         Return a list of the nodes in the graph.
         """
-        return list(self.keys())
+        return set(self.keys())
 
     def add_node(self, name, institution, year, id, advisors, advisees, is_seed=False):
         """
@@ -141,15 +141,11 @@ of Node objects for 'seed_nodes'"
 
             sorted_ancestors = sorted(
                 [a for a in node.ancestors if a in self],
-                lambda x, y: cmp(
-                    self[x].record.name.split()[-1], self[y].record.name.split()[-1]
-                ),
+                key=lambda n: self[n].record.name.split()[-1]
             )
             sorted_descendants = sorted(
                 [d for d in node.descendants if d in self],
-                lambda x, y: cmp(
-                    self[x].record.name.split()[-1], self[y].record.name.split()[-1]
-                ),
+                key=lambda n: self[n].record.name.split()[-1]
             )
 
             if include_ancestors:

--- a/geneagrapher/graph/node.py
+++ b/geneagrapher/graph/node.py
@@ -1,6 +1,8 @@
+import functools
 from .record import Record
 
 
+@functools.total_ordering
 class Node:
     """
     Container class storing a node in the graph.
@@ -39,11 +41,14 @@ for 'ancestors'"
 for 'descendants'"
             )
 
-    def __unicode__(self):
-        return self.record.__unicode__()
+    def __str__(self):
+        return str(self.record)
 
-    def __cmp__(self, n2):
-        return self.record.__cmp__(n2.record)
+    def __eq__(self, n2):
+        return self.record == n2.record
+
+    def __lt__(self, n2):
+        return self.record < n2.record
 
     def __hash__(self):
         return hash(self.get_id())

--- a/geneagrapher/graph/node.py
+++ b/geneagrapher/graph/node.py
@@ -1,4 +1,4 @@
-from record import Record
+from .record import Record
 
 
 class Node:

--- a/geneagrapher/graph/record.py
+++ b/geneagrapher/graph/record.py
@@ -1,3 +1,7 @@
+import functools
+
+
+@functools.total_ordering
 class Record:
     """
     Container class storing record of a mathematician in the graph.
@@ -44,13 +48,14 @@ value for 'year'"
 value for 'id'"
             )
 
-    def __cmp__(self, r2):
-        """
-        Compare a pair of mathematician records based on ids.
-        """
-        return self.id.__cmp__(r2.id)
+    def __eq__(self, r2):
+        return self.id == r2.id
 
-    def __unicode__(self):
+    def __lt__(self, r2):
+        return self.id < r2.id
+
+
+    def __str__(self):
         if self.has_institution():
             if self.has_year():
                 return "{} \\n{} ({})".format(self.name, self.institution, self.year)

--- a/geneagrapher/graph/record.py
+++ b/geneagrapher/graph/record.py
@@ -20,13 +20,13 @@ class Record:
         self.id = id
 
         # Verify we got the types wanted.
-        if not isinstance(self.name, basestring):
+        if not isinstance(self.name, str):
             raise TypeError(
                 "Unexpected parameter type: expected string value \
 for 'name'"
             )
         if (
-            not isinstance(self.institution, basestring)
+            not isinstance(self.institution, str)
             and self.institution is not None
         ):
             raise TypeError(
@@ -53,12 +53,12 @@ value for 'id'"
     def __unicode__(self):
         if self.has_institution():
             if self.has_year():
-                return u"{} \\n{} ({})".format(self.name, self.institution, self.year)
+                return "{} \\n{} ({})".format(self.name, self.institution, self.year)
             else:
-                return u"{} \\n{}".format(self.name, self.institution)
+                return "{} \\n{}".format(self.name, self.institution)
         else:
             if self.has_year():
-                return u"{} \\n({})".format(self.name, self.year)
+                return "{} \\n({})".format(self.name, self.year)
             else:
                 return self.name
 

--- a/setup.py
+++ b/setup.py
@@ -31,4 +31,6 @@ setuptools.setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
+    package_data={'tests': ['geneagrapher/testdata/*.html']},
+    include_package_data=True,
 )

--- a/tests/geneagrapher/test_cache_grabber.py
+++ b/tests/geneagrapher/test_cache_grabber.py
@@ -1,7 +1,7 @@
 import os
 from time import time
 import unittest
-from local_data_grabber import LocalDataGrabber
+from .local_data_grabber import LocalDataGrabber
 from geneagrapher.cache_grabber import CacheGrabber
 from geneagrapher.grabber import Grabber
 
@@ -10,8 +10,8 @@ class TestCacheGrabberMethods(unittest.TestCase):
     """Unit tests for the geneagrapher.CacheGrabber class."""
 
     def setUp(self):
-        self.name = u"Carl Friedrich Gau\xdf"
-        self.institution = u"Universit\xe4t Helmstedt"
+        self.name = "Carl Friedrich Gau\xdf"
+        self.institution = "Universit\xe4t Helmstedt"
         self.year = 1799
         self.advisors = set([18230])
         self.descendants = set(
@@ -62,7 +62,7 @@ class TestCacheGrabberMethods(unittest.TestCase):
         cache = CacheGrabber(record_grabber=LocalDataGrabber)
         self.assertEqual(len(cache.cache), 0)
         cache.close()
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError, "invalid operation on closed shelf", len, cache.cache
         )
 
@@ -100,7 +100,7 @@ class TestCacheGrabberMethods(unittest.TestCase):
         """Test the context manager methods."""
         with CacheGrabber(record_grabber=LocalDataGrabber) as cache:
             self.assertEqual(len(cache.cache), 0)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError, "invalid operation on closed shelf", len, cache.cache
         )
 
@@ -108,7 +108,7 @@ class TestCacheGrabberMethods(unittest.TestCase):
         """Test the get_record method for a bad id."""
         with CacheGrabber(record_grabber=LocalDataGrabber) as cache:
             self.assertEqual(len(cache.cache), 0)
-            self.assertRaisesRegexp(
+            self.assertRaisesRegex(
                 ValueError, "Invalid id 999999999", cache.get_record, 999999999
             )
             self.assertEqual(len(cache.cache), 0)
@@ -118,8 +118,8 @@ class TestCacheGrabberMethods(unittest.TestCase):
         with CacheGrabber(record_grabber=LocalDataGrabber) as cache:
             record = cache.get_record(18231)
             self.assertEqual(len(record), 6)
-            self.assertEqual(record["name"], u"Carl Friedrich Gau\xdf")
-            self.assertEqual(record["institution"], u"Universit\xe4t Helmstedt")
+            self.assertEqual(record["name"], "Carl Friedrich Gau\xdf")
+            self.assertEqual(record["institution"], "Universit\xe4t Helmstedt")
             self.assertEqual(record["year"], 1799)
             self.assertEqual(record["advisors"], set([18230]))
             self.assertEqual(
@@ -149,12 +149,12 @@ class TestCacheGrabberMethods(unittest.TestCase):
 
             # Make the request again and verify the cached version is returned.
             d = cache.cache["18231"]
-            d["institution"] = u"Rigged for test"
+            d["institution"] = "Rigged for test"
             cache.cache["18231"] = d
             record = cache.get_record(18231)
             self.assertEqual(len(record), 6)
-            self.assertEqual(record["name"], u"Carl Friedrich Gau\xdf")
-            self.assertEqual(record["institution"], u"Rigged for test")
+            self.assertEqual(record["name"], "Carl Friedrich Gau\xdf")
+            self.assertEqual(record["institution"], "Rigged for test")
             self.assertEqual(record["year"], 1799)
             self.assertEqual(record["advisors"], set([18230]))
             self.assertEqual(
@@ -179,7 +179,7 @@ class TestCacheGrabberMethods(unittest.TestCase):
                     ]
                 ),
             )
-            self.assertEqual(record["message"], u"cache hit")
+            self.assertEqual(record["message"], "cache hit")
             self.assertEqual(len(cache.cache), 1)
 
         with CacheGrabber(record_grabber=LocalDataGrabber) as cache:
@@ -187,12 +187,12 @@ class TestCacheGrabberMethods(unittest.TestCase):
             # of the cache from disk.
             self.assertEqual(len(cache.cache), 1)
             d = cache.cache["18231"]
-            d["institution"] = u"Rigged for test"
+            d["institution"] = "Rigged for test"
             cache.cache["18231"] = d
             record = cache.get_record(18231)
             self.assertEqual(len(record), 6)
-            self.assertEqual(record["name"], u"Carl Friedrich Gau\xdf")
-            self.assertEqual(record["institution"], u"Rigged for test")
+            self.assertEqual(record["name"], "Carl Friedrich Gau\xdf")
+            self.assertEqual(record["institution"], "Rigged for test")
             self.assertEqual(record["year"], 1799)
             self.assertEqual(record["advisors"], set([18230]))
             self.assertEqual(
@@ -217,7 +217,7 @@ class TestCacheGrabberMethods(unittest.TestCase):
                     ]
                 ),
             )
-            self.assertEqual(record["message"], u"cache hit")
+            self.assertEqual(record["message"], "cache hit")
             self.assertEqual(len(cache.cache), 1)
 
             # Make another request, this time with the cached entry expired,
@@ -226,8 +226,8 @@ class TestCacheGrabberMethods(unittest.TestCase):
             cache.cache["18231"] = d
             record = cache.get_record(18231)
             self.assertEqual(len(record), 6)
-            self.assertEqual(record["name"], u"Carl Friedrich Gau\xdf")
-            self.assertEqual(record["institution"], u"Universit\xe4t Helmstedt")
+            self.assertEqual(record["name"], "Carl Friedrich Gau\xdf")
+            self.assertEqual(record["institution"], "Universit\xe4t Helmstedt")
             self.assertEqual(record["year"], 1799)
             self.assertEqual(record["advisors"], set([18230]))
             self.assertEqual(
@@ -252,7 +252,7 @@ class TestCacheGrabberMethods(unittest.TestCase):
                     ]
                 ),
             )
-            self.assertEqual(record["message"], u"cache miss")
+            self.assertEqual(record["message"], "cache miss")
             self.assertEqual(len(cache.cache), 1)
 
     def test_is_in_cache(self):

--- a/tests/geneagrapher/test_cache_grabber.py
+++ b/tests/geneagrapher/test_cache_grabber.py
@@ -20,7 +20,7 @@ class TestCacheGrabberMethods(unittest.TestCase):
 
     def tearDown(self):
         try:
-            os.remove("geneacache")
+            os.remove("geneacache.db")
         except OSError:
             pass
 
@@ -39,7 +39,7 @@ class TestCacheGrabberMethods(unittest.TestCase):
         self.assertEqual(len(cache.cache), 0)
         self.assertIsInstance(cache.grabber, Grabber)
         self.assertEqual(cache.expiration_interval, 604800.)
-        os.remove("mycachename")
+        os.remove("mycachename.db")
 
     def test_init3(self):
         """Test constructor with non-default record grabber."""

--- a/tests/geneagrapher/test_geneagrapher_methods.py
+++ b/tests/geneagrapher/test_geneagrapher_methods.py
@@ -38,12 +38,12 @@ class TestGeneagrapherMethods(unittest.TestCase):
 [-d] [--disable-cache]
                     [--cache-file FILE] [-v]
                     ID [ID ...]
-geneagrapher: error: too few arguments
+geneagrapher: error: the following arguments are required: ID
 """
         try:
             self.ggrapher.parse_input()
         except SystemExit:
-            self.assertEqual(stderr_intercept.getvalue().decode("utf-8"), expected)
+            self.assertEqual(stderr_intercept.getvalue(), expected)
 
         sys.stderr = stderr
 
@@ -185,11 +185,7 @@ geneagrapher: error: too few arguments
         self.assertEqual(record.year, 1672)
         self.assertEqual(record.id, 127946)
 
-        self.assertEqual(
-            stdout_intercept.getvalue().decode("utf-8"), "Grabbing record #127946...\n"
-        )
-        self.assertEqual(stdout_intercept.getvalue().decode('utf-8'),
-                         "Grabbing record #127946...\n")
+        self.assertEqual(stdout_intercept.getvalue(), "Grabbing record #127946...\n")
 
     def test_build_graph_complete_with_ancestors(self):
         """Graph building with ancestors."""
@@ -328,7 +324,7 @@ geneagrapher: error: too few arguments
 
 }
 """
-        self.assertEqual(stdout_intercept.getvalue().decode("utf-8"), expected)
+        self.assertEqual(stdout_intercept.getvalue(), expected)
 
     def test_end_to_end_cached_self_stdout(self):
         """Complete test using cache getting no ancestors or descendants and
@@ -401,7 +397,7 @@ geneagrapher: error: too few arguments
     143630 -> 137705;
 }
 """
-        self.assertEqual(stdout_intercept.getvalue().decode("utf-8"), expected)
+        self.assertEqual(stdout_intercept.getvalue(), expected)
 
     def test_end_to_end_descendants_stdout(self):
         """
@@ -437,7 +433,7 @@ geneagrapher: error: too few arguments
     79568 -> 99457;
 }
 """
-        self.assertEqual(stdout_intercept.getvalue().decode("utf-8"), expected)
+        self.assertEqual(stdout_intercept.getvalue(), expected)
 
     def test_end_to_end_self_file(self):
         """Complete test getting no ancestors or descendants and writing the
@@ -465,7 +461,7 @@ geneagrapher: error: too few arguments
 }
 """
         with open(outfname, "r") as fin:
-            self.assertEqual(fin.read().decode("utf-8"), expected)
+            self.assertEqual(fin.read(), expected)
         os.remove(outfname)
 
     def test_end_to_end_through_ggrapher_self_stdout(self):

--- a/tests/geneagrapher/test_geneagrapher_methods.py
+++ b/tests/geneagrapher/test_geneagrapher_methods.py
@@ -1,11 +1,11 @@
 import os
 import sys
 import unittest
-import StringIO
+import io
 from geneagrapher import geneagrapher
 from geneagrapher.cache_grabber import CacheGrabber
 from geneagrapher.graph import Graph
-from local_data_grabber import LocalDataGrabber
+from .local_data_grabber import LocalDataGrabber
 
 
 class TestGeneagrapherMethods(unittest.TestCase):
@@ -31,7 +31,7 @@ class TestGeneagrapherMethods(unittest.TestCase):
 
         # Redirect stderr to capture output.
         stderr = sys.stderr
-        stderr_intercept = StringIO.StringIO()
+        stderr_intercept = io.StringIO()
         sys.stderr = stderr_intercept
 
         expected = """usage: geneagrapher [-h] [--version] [-f FILE] [-a] \
@@ -166,7 +166,7 @@ geneagrapher: error: too few arguments
 
         # Redirect stdout to capture output.
         stdout = sys.stdout
-        stdout_intercept = StringIO.StringIO()
+        stdout_intercept = io.StringIO()
         sys.stdout = stdout_intercept
         self.ggrapher.build_graph_complete(LocalDataGrabber)
         sys.stdout = stdout
@@ -186,8 +186,10 @@ geneagrapher: error: too few arguments
         self.assertEqual(record.id, 127946)
 
         self.assertEqual(
-            stdout_intercept.getvalue().decode("utf-8"), u"Grabbing record #127946...\n"
+            stdout_intercept.getvalue().decode("utf-8"), "Grabbing record #127946...\n"
         )
+        self.assertEqual(stdout_intercept.getvalue().decode('utf-8'),
+                         "Grabbing record #127946...\n")
 
     def test_build_graph_complete_with_ancestors(self):
         """Graph building with ancestors."""
@@ -217,7 +219,7 @@ geneagrapher: error: too few arguments
 
         record = node.record
         self.assertEqual(record.name, "Valentin  Alberti")
-        self.assertEqual(record.institution, u"Universit\xe4t Leipzig")
+        self.assertEqual(record.institution, "Universit\xe4t Leipzig")
         self.assertEqual(record.year, 1678)
         self.assertEqual(record.id, 137717)
 
@@ -227,7 +229,7 @@ geneagrapher: error: too few arguments
 
         record = node.record
         self.assertEqual(record.name, "Jakob  Thomasius")
-        self.assertEqual(record.institution, u"Universit\xe4t Leipzig")
+        self.assertEqual(record.institution, "Universit\xe4t Leipzig")
         self.assertEqual(record.year, 1643)
         self.assertEqual(record.id, 137705)
 
@@ -258,7 +260,7 @@ geneagrapher: error: too few arguments
 
         record = node.record
         self.assertEqual(record.name, "Ramdas  Kumaresan")
-        self.assertEqual(record.institution, u"University of Rhode Island")
+        self.assertEqual(record.institution, "University of Rhode Island")
         self.assertEqual(record.year, 1982)
         self.assertEqual(record.id, 79568)
 
@@ -268,7 +270,7 @@ geneagrapher: error: too few arguments
 
         record = node.record
         self.assertEqual(record.name, "C. S. Ramalingam")
-        self.assertEqual(record.institution, u"University of Rhode Island")
+        self.assertEqual(record.institution, "University of Rhode Island")
         self.assertEqual(record.year, 1995)
         self.assertEqual(record.id, 79562)
 
@@ -278,7 +280,7 @@ geneagrapher: error: too few arguments
 
         record = node.record
         self.assertEqual(record.name, "Yadong  Wang")
-        self.assertEqual(record.institution, u"University of Rhode Island")
+        self.assertEqual(record.institution, "University of Rhode Island")
         self.assertEqual(record.year, 2003)
         self.assertEqual(record.id, 99457)
 
@@ -311,12 +313,12 @@ geneagrapher: error: too few arguments
 
         # Redirect stdout to capture output.
         stdout = sys.stdout
-        stdout_intercept = StringIO.StringIO()
+        stdout_intercept = io.StringIO()
         sys.stdout = stdout_intercept
         self.ggrapher.generate_dot_file()
         sys.stdout = stdout
 
-        expected = u"""digraph genealogy {
+        expected = """digraph genealogy {
     graph [charset="utf-8"];
     node [shape=plaintext];
     edge [style=bold];
@@ -379,12 +381,12 @@ geneagrapher: error: too few arguments
 
         # Redirect stdout to capture output.
         stdout = sys.stdout
-        stdout_intercept = StringIO.StringIO()
+        stdout_intercept = io.StringIO()
         sys.stdout = stdout_intercept
         self.ggrapher.generate_dot_file()
         sys.stdout = stdout
 
-        expected = u"""digraph genealogy {
+        expected = """digraph genealogy {
     graph [charset="utf-8"];
     node [shape=plaintext];
     edge [style=bold];
@@ -417,12 +419,12 @@ geneagrapher: error: too few arguments
 
         # Redirect stdout to capture output.
         stdout = sys.stdout
-        stdout_intercept = StringIO.StringIO()
+        stdout_intercept = io.StringIO()
         sys.stdout = stdout_intercept
         self.ggrapher.generate_dot_file()
         sys.stdout = stdout
 
-        expected = u"""digraph genealogy {
+        expected = """digraph genealogy {
     graph [charset="utf-8"];
     node [shape=plaintext];
     edge [style=bold];
@@ -452,7 +454,7 @@ geneagrapher: error: too few arguments
         self.ggrapher.build_graph_complete(LocalDataGrabber)
         self.ggrapher.generate_dot_file()
 
-        expected = u"""digraph genealogy {
+        expected = """digraph genealogy {
     graph [charset="utf-8"];
     node [shape=plaintext];
     edge [style=bold];

--- a/tests/geneagrapher/test_grabber_methods.py
+++ b/tests/geneagrapher/test_grabber_methods.py
@@ -3,7 +3,7 @@ import sys
 from bs4 import BeautifulSoup
 import unittest
 from geneagrapher.grabber import *
-from local_data_grabber import LocalDataGrabber
+from .local_data_grabber import LocalDataGrabber
 
 
 class TestGrabberMethods(unittest.TestCase):
@@ -81,8 +81,8 @@ class TestGrabberMethods(unittest.TestCase):
             soup = BeautifulSoup(fin, "lxml")
         record = get_record_from_tree(soup, 18231)
         self.assertEqual(len(record), 5)
-        self.assertEqual(record["name"], u"Carl Friedrich Gau\xdf")
-        self.assertEqual(record["institution"], u"Universit\xe4t Helmstedt")
+        self.assertEqual(record["name"], "Carl Friedrich Gau\xdf")
+        self.assertEqual(record["institution"], "Universit\xe4t Helmstedt")
         self.assertEqual(record["year"], 1799)
         self.assertEqual(record["advisors"], set([18230]))
         self.assertEqual(
@@ -112,8 +112,8 @@ class TestGrabberMethods(unittest.TestCase):
         # effect.
         record = get_record_from_tree(soup, 18231)
         self.assertEqual(len(record), 5)
-        self.assertEqual(record["name"], u"Carl Friedrich Gau\xdf")
-        self.assertEqual(record["institution"], u"Universit\xe4t Helmstedt")
+        self.assertEqual(record["name"], "Carl Friedrich Gau\xdf")
+        self.assertEqual(record["institution"], "Universit\xe4t Helmstedt")
         self.assertEqual(record["year"], 1799)
         self.assertEqual(record["advisors"], set([18230]))
         self.assertEqual(
@@ -157,7 +157,10 @@ class TestGrabberMethods(unittest.TestCase):
         """Test the get_name() method."""
         with open(self.data_file("137717.html"), "r") as fin:
             soup = BeautifulSoup(fin, "lxml")
-            self.assertEqual(u"Valentin  Alberti", get_name(soup))
+            self.assertEqual("Valentin  Alberti", get_name(soup))
+        with open(self.data_file('137717.html'), 'r') as fin:
+            soup = BeautifulSoup(fin, 'lxml')
+            self.assertEqual("Valentin  Alberti", get_name(soup))
 
     def test_get_name_slash_l(self):
         """Test the get_name() method for a record containing a non-ASCII
@@ -165,15 +168,19 @@ class TestGrabberMethods(unittest.TestCase):
         with open(self.data_file("7383.html"), "r") as fin:
             soup = BeautifulSoup(fin, "lxml")
             self.assertEqual(
-                u"W\u0142adys\u0142aw Hugo Dyonizy Steinhaus", get_name(soup)
+                "W\u0142adys\u0142aw Hugo Dyonizy Steinhaus", get_name(soup)
             )
+        with open(self.data_file('7383.html'), 'r') as fin:
+            soup = BeautifulSoup(fin, 'lxml')
+            self.assertEqual("W\u0142adys\u0142aw Hugo Dyonizy Steinhaus",
+                             get_name(soup))
 
     def test_get_institution(self):
         """Test the get_institution() method for a record with an
         institution."""
         with open(self.data_file("137717.html"), "r") as fin:
             soup = BeautifulSoup(fin, "lxml")
-            self.assertEqual(u"Universit\xe4t Leipzig", get_institution(soup))
+            self.assertEqual("Universit\xe4t Leipzig", get_institution(soup))
 
     def test_get_institution_no_institution(self):
         """Test the get_institution() method for a record with no

--- a/tests/geneagrapher/test_graph_methods.py
+++ b/tests/geneagrapher/test_graph_methods.py
@@ -58,28 +58,26 @@ class TestGraphMethods(unittest.TestCase):
 
     def test_get_node_list(self):
         """Test the get_node_list() method."""
-        self.assertEqual(self.graph1.get_node_list(), [18231])
+        self.assertEqual(self.graph1.get_node_list(), set([18231]))
 
     def test_get_node_list_empty(self):
         """Test the get_node_list() method for an empty graph."""
         graph = Graph()
-        self.assertEqual(graph.get_node_list(), [])
+        self.assertEqual(graph.get_node_list(), set())
 
     def test_add_node(self):
         """Test the add_node() method."""
         self.graph1.add_node(
-            "Leonhard Euler", "Universitaet Basel", 1726, 38586, set(), set()
-        )
-        self.assertEqual([38586, 18231], self.graph1.get_node_list())
+            "Leonhard Euler", "Universitaet Basel", 1726, 38586, set(), set())
+        self.assertEqual(set([38586, 18231]), self.graph1.get_node_list())
         self.assertEqual(self.graph1.seeds, set([18231]))
 
     def test_add_second_node_seed(self):
         """Test the add_node() method when adding a second node and
         marking it as a seed node."""
         self.graph1.add_node(
-            "Leonhard Euler", "Universitaet Basel", 1726, 38586, set(), set(), True
-        )
-        self.assertEqual([38586, 18231], self.graph1.get_node_list())
+            "Leonhard Euler", "Universitaet Basel", 1726, 38586, set(), set(), True)
+        self.assertEqual(set([38586, 18231]), self.graph1.get_node_list())
         self.assertEqual(self.graph1.seeds, set([18231, 38586]))
 
     def test_add_node_seed(self):
@@ -94,9 +92,8 @@ class TestGraphMethods(unittest.TestCase):
     def test_add_node_already_present(self):
         """Test for expected exception when adding a duplicate node."""
         self.graph1.add_node(
-            "Leonhard Euler", "Universitaet Basel", 1726, 38586, set(), set()
-        )
-        self.assertEqual([38586, 18231], self.graph1.get_node_list())
+            "Leonhard Euler", "Universitaet Basel", 1726, 38586, set(), set())
+        self.assertEqual(set([38586, 18231]), self.graph1.get_node_list())
         self.assertRaises(
             DuplicateNodeError,
             self.graph1.add_node,
@@ -122,7 +119,7 @@ class TestGraphMethods(unittest.TestCase):
         record = Record("Leonhard Euler", "Universitaet Basel", 1726, 38586)
         node = Node(record, set(), set())
         self.graph1.add_node_object(node)
-        self.assertEqual([38586, 18231], self.graph1.get_node_list())
+        self.assertEqual(set([38586, 18231]), self.graph1.get_node_list())
         self.assertEqual(self.graph1.seeds, set([18231]))
 
     def test_generate_dot_file(self):

--- a/tests/geneagrapher/test_graph_methods.py
+++ b/tests/geneagrapher/test_graph_methods.py
@@ -7,7 +7,7 @@ class TestGraphMethods(unittest.TestCase):
 
     def setUp(self):
         self.record1 = Record(
-            u"Carl Friedrich Gau\xdf", u"Universit\xe4t Helmstedt", 1799, 18231
+            "Carl Friedrich Gau\xdf", u"Universit\xe4t Helmstedt", 1799, 18231
         )
         self.node1 = Node(self.record1, set(), set())
         self.graph1 = Graph(set([self.node1]))
@@ -20,7 +20,7 @@ class TestGraphMethods(unittest.TestCase):
     def test_init(self):
         """Test the constructor."""
         self.assertEqual(self.graph1.seeds, set([18231]))
-        self.assertEqual(self.graph1.keys(), [18231])
+        self.assertEqual(list(self.graph1.keys()), [18231])
         self.assertEqual(self.graph1[18231], self.node1)
 
     def test_init_bad_seeds(self):
@@ -48,7 +48,7 @@ class TestGraphMethods(unittest.TestCase):
     def test_get_node(self):
         """Test the get_node() method."""
         node = self.graph1.get_node(18231)
-        self.assert_(node == self.node1)
+        self.assertTrue(node == self.node1)
 
     def test_get_node_not_found(self):
         """
@@ -127,7 +127,7 @@ class TestGraphMethods(unittest.TestCase):
 
     def test_generate_dot_file(self):
         """Test the generate_dot_file() method."""
-        dotfileexpt = u"""digraph genealogy {
+        dotfileexpt = """digraph genealogy {
     graph [charset="utf-8"];
     node [shape=plaintext];
     edge [style=bold];
@@ -145,50 +145,50 @@ class TestGraphMethods(unittest.TestCase):
         This is a larger example than test_generate_dot_file()."""
         graph = Graph()
         graph.add_node(
-            u"Carl Friedrich Gau\xdf",
-            u"Universit\xe4t Helmstedt",
+            "Carl Friedrich Gau\xdf",
+            "Universit\xe4t Helmstedt",
             1799,
             18231,
             set([18230]),
             set(),
         )
         graph.add_node(
-            u"Johann Friedrich Pfaff",
-            u"Georg-August-Universit\xe4t Goettingen",
+            "Johann Friedrich Pfaff",
+            "Georg-August-Universit\xe4t Goettingen",
             1786,
             18230,
             set([66476]),
             set([18231]),
         )
         graph.add_node(
-            u"Abraham Gotthelf Kaestner",
-            u"Universit\xe4t Leipzig",
+            "Abraham Gotthelf Kaestner",
+            "Universit\xe4t Leipzig",
             1739,
             66476,
             set([57670]),
             set([18230]),
         )
         graph.add_node(
-            u"Christian August Hausen",
-            u"Martin-Luther-Universit\xe4t Halle-Wittenberg",
+            "Christian August Hausen",
+            "Martin-Luther-Universit\xe4t Halle-Wittenberg",
             1713,
             57670,
             set([72669]),
             set([66476]),
         )
         graph.add_node(
-            u"Johann Christoph Wichmannshausen",
-            u"Universit\xe4t Leipzig",
+            "Johann Christoph Wichmannshausen",
+            "Universit\xe4t Leipzig",
             1685,
             72669,
             set([21235]),
             set([57670]),
         )
         graph.add_node(
-            u"Otto Mencke", u"Universit\xe4t Leipzig", 1665, 21235, set(), set([72669])
+            "Otto Mencke", "Universit\xe4t Leipzig", 1665, 21235, set(), set([72669])
         )
 
-        dotfileexpt = u"""digraph genealogy {
+        dotfileexpt = """digraph genealogy {
     graph [charset="utf-8"];
     node [shape=plaintext];
     edge [style=bold];
@@ -218,8 +218,8 @@ Halle-Wittenberg (1713)"];
         graph's nodes as they are added."""
         graph = Graph()
         graph.add_node(
-            u"Carl Friedrich Gau\xdf",
-            u"Universit\xe4t Helmstedt",
+            "Carl Friedrich Gau\xdf",
+            "Universit\xe4t Helmstedt",
             1799,
             18231,
             set([18230]),
@@ -230,8 +230,8 @@ Halle-Wittenberg (1713)"];
         self.assertEqual(node1.descendants, set())
 
         graph.add_node(
-            u"Johann Friedrich Pfaff",
-            u"Georg-August-Universit\xe4t Goettingen",
+            "Johann Friedrich Pfaff",
+            "Georg-August-Universit\xe4t Goettingen",
             1786,
             18230,
             set([66476]),
@@ -244,8 +244,8 @@ Halle-Wittenberg (1713)"];
         self.assertEqual(node2.descendants, set([18231]))
 
         graph.add_node(
-            u"Abraham Gotthelf Kaestner",
-            u"Universit\xe4t Leipzig",
+            "Abraham Gotthelf Kaestner",
+            "Universit\xe4t Leipzig",
             1739,
             66476,
             set([57670]),
@@ -260,8 +260,8 @@ Halle-Wittenberg (1713)"];
         self.assertEqual(node3.descendants, set([18230]))
 
         graph.add_node(
-            u"Christian August Hausen",
-            u"Martin-Luther-Universit\xe4t Halle-Wittenberg",
+            "Christian August Hausen",
+            "Martin-Luther-Universit\xe4t Halle-Wittenberg",
             1713,
             57670,
             set([72669]),
@@ -278,8 +278,8 @@ Halle-Wittenberg (1713)"];
         self.assertEqual(node4.descendants, set([66476]))
 
         graph.add_node(
-            u"Johann Christoph Wichmannshausen",
-            u"Universit\xe4t Leipzig",
+            "Johann Christoph Wichmannshausen",
+            "Universit\xe4t Leipzig",
             1685,
             72669,
             set([21235]),
@@ -298,7 +298,7 @@ Halle-Wittenberg (1713)"];
         self.assertEqual(node5.descendants, set([57670]))
 
         graph.add_node(
-            u"Otto Mencke", u"Universit\xe4t Leipzig", 1665, 21235, set(), set([72669])
+            "Otto Mencke", "Universit\xe4t Leipzig", 1665, 21235, set(), set([72669])
         )
         node6 = graph[21235]
         self.assertEqual(node1.ancestors, set([18230]))
@@ -320,8 +320,8 @@ Halle-Wittenberg (1713)"];
         # in the previous test."""
         graph = Graph()
         graph.add_node(
-            u"Abraham Gotthelf Kaestner",
-            u"Universit\xe4t Leipzig",
+            "Abraham Gotthelf Kaestner",
+            "Universit\xe4t Leipzig",
             1739,
             66476,
             set([57670]),
@@ -332,8 +332,8 @@ Halle-Wittenberg (1713)"];
         self.assertEqual(node1.descendants, set())
 
         graph.add_node(
-            u"Johann Friedrich Pfaff",
-            u"Georg-August-Universit\xe4t Goettingen",
+            "Johann Friedrich Pfaff",
+            "Georg-August-Universit\xe4t Goettingen",
             1786,
             18230,
             set([66476]),
@@ -346,8 +346,8 @@ Halle-Wittenberg (1713)"];
         self.assertEqual(node2.descendants, set())
 
         graph.add_node(
-            u"Christian August Hausen",
-            u"Martin-Luther-Universit\xe4t Halle-Wittenberg",
+            "Christian August Hausen",
+            "Martin-Luther-Universit\xe4t Halle-Wittenberg",
             1713,
             57670,
             set([72669]),
@@ -362,8 +362,8 @@ Halle-Wittenberg (1713)"];
         self.assertEqual(node3.descendants, set([66476]))
 
         graph.add_node(
-            u"Johann Christoph Wichmannshausen",
-            u"Universit\xe4t Leipzig",
+            "Johann Christoph Wichmannshausen",
+            "Universit\xe4t Leipzig",
             1685,
             72669,
             set([21235]),
@@ -380,7 +380,7 @@ Halle-Wittenberg (1713)"];
         self.assertEqual(node4.descendants, set([57670]))
 
         graph.add_node(
-            u"Otto Mencke", u"Universit\xe4t Leipzig", 1665, 21235, set(), set([72669])
+            "Otto Mencke", "Universit\xe4t Leipzig", 1665, 21235, set(), set([72669])
         )
         node5 = graph[21235]
         self.assertEqual(node1.ancestors, set([57670]))
@@ -395,8 +395,8 @@ Halle-Wittenberg (1713)"];
         self.assertEqual(node5.descendants, set([72669]))
 
         graph.add_node(
-            u"Carl Friedrich Gau\xdf",
-            u"Universit\xe4t Helmstedt",
+            "Carl Friedrich Gau\xdf",
+            "Universit\xe4t Helmstedt",
             1799,
             18231,
             set([18230]),

--- a/tests/geneagrapher/test_node_methods.py
+++ b/tests/geneagrapher/test_node_methods.py
@@ -32,55 +32,57 @@ class TestNodeMethods(unittest.TestCase):
         list."""
         self.assertRaises(TypeError, Node, self.record, set(), 1)
 
-    def test_unicode_full(self):
-        """Test __unicode__() method for Node with complete record."""
+    def test_str_full(self):
+        """Test __str__() method for Node with complete record."""
         node = Node(self.record, set(), set())
-        nodestr = node.__unicode__()
+        nodestr = str(node)
         nodestrexpt = "Carl Friedrich Gau\xdf \\nUniversit\xe4t Helmstedt \
 (1799)"
         self.assertEqual(nodestr, nodestrexpt)
 
-    def test_unicode_no_year(self):
+    def test_str_no_year(self):
         """
-        Test __unicode__() method for Node containing record without year.
+        Test __str__() method for Node containing record without year.
         """
         record = Record(self.record.name, self.record.institution, None, 18231)
         node = Node(record, set(), set())
-        nodestr = node.__unicode__()
+        nodestr = str(node)
         nodestrexpt = "Carl Friedrich Gau\xdf \\nUniversit\xe4t Helmstedt"
         self.assertEqual(nodestr, nodestrexpt)
 
-    def test_unicode_no_inst(self):
-        """Test __unicode__() method for Node containing record without
+    def test_str_no_inst(self):
+        """Test __str__() method for Node containing record without
         institution."""
         record = Record(self.record.name, None, 1799, 18231)
         node = Node(record, set(), set())
-        nodestr = node.__unicode__()
+        nodestr = str(node)
         nodestrexpt = "Carl Friedrich Gau\xdf \\n(1799)"
         self.assertEqual(nodestr, nodestrexpt)
 
-    def test_unicode_no_inst_no_id(self):
-        """Test __unicode__() method for Node containing record without
+    def test_str_no_inst_no_id(self):
+        """Test __stre__() method for Node containing record without
         institution or year."""
         record = Record(self.record.name, None, None, 18231)
         node = Node(record, set(), set())
-        nodestr = node.__unicode__()
+        nodestr = str(node)
         nodestrexpt = "Carl Friedrich Gau\xdf"
         self.assertEqual(nodestr, nodestrexpt)
 
-    def test_cmp_equal(self):
+    def test_equal(self):
         """Test comparison method for Nodes with identical records."""
         record2 = Record("Carl Friedrich Gauss", "Universitaet Helmstedt", 1799, 18231)
         node1 = Node(self.record, set(), set())
         node2 = Node(record2, set(), set())
         self.assertTrue(node1 == node2)
 
-    def test_cmp_unequal(self):
+    def test_unequal(self):
         """Test comparison method for Nodes with different records."""
         record2 = Record("Leonhard Euler", "Universitaet Basel", 1726, 38586)
         node1 = Node(self.record, set(), set())
         node2 = Node(record2, set(), set())
         self.assertTrue(node1 < node2)
+        self.assertTrue(node1 != node2)
+        self.assertTrue(node2 > node1)
 
     def test_add_ancestor(self):
         """Test the add_ancestor() method."""

--- a/tests/geneagrapher/test_node_methods.py
+++ b/tests/geneagrapher/test_node_methods.py
@@ -7,7 +7,7 @@ class TestNodeMethods(unittest.TestCase):
 
     def setUp(self):
         self.record = Record(
-            u"Carl Friedrich Gau\xdf", u"Universit\xe4t Helmstedt", 1799, 18231
+            "Carl Friedrich Gau\xdf", "Universit\xe4t Helmstedt", 1799, 18231
         )
 
     def test_init(self):
@@ -36,7 +36,7 @@ class TestNodeMethods(unittest.TestCase):
         """Test __unicode__() method for Node with complete record."""
         node = Node(self.record, set(), set())
         nodestr = node.__unicode__()
-        nodestrexpt = u"Carl Friedrich Gau\xdf \\nUniversit\xe4t Helmstedt \
+        nodestrexpt = "Carl Friedrich Gau\xdf \\nUniversit\xe4t Helmstedt \
 (1799)"
         self.assertEqual(nodestr, nodestrexpt)
 
@@ -47,7 +47,7 @@ class TestNodeMethods(unittest.TestCase):
         record = Record(self.record.name, self.record.institution, None, 18231)
         node = Node(record, set(), set())
         nodestr = node.__unicode__()
-        nodestrexpt = u"Carl Friedrich Gau\xdf \\nUniversit\xe4t Helmstedt"
+        nodestrexpt = "Carl Friedrich Gau\xdf \\nUniversit\xe4t Helmstedt"
         self.assertEqual(nodestr, nodestrexpt)
 
     def test_unicode_no_inst(self):
@@ -56,7 +56,7 @@ class TestNodeMethods(unittest.TestCase):
         record = Record(self.record.name, None, 1799, 18231)
         node = Node(record, set(), set())
         nodestr = node.__unicode__()
-        nodestrexpt = u"Carl Friedrich Gau\xdf \\n(1799)"
+        nodestrexpt = "Carl Friedrich Gau\xdf \\n(1799)"
         self.assertEqual(nodestr, nodestrexpt)
 
     def test_unicode_no_inst_no_id(self):
@@ -65,7 +65,7 @@ class TestNodeMethods(unittest.TestCase):
         record = Record(self.record.name, None, None, 18231)
         node = Node(record, set(), set())
         nodestr = node.__unicode__()
-        nodestrexpt = u"Carl Friedrich Gau\xdf"
+        nodestrexpt = "Carl Friedrich Gau\xdf"
         self.assertEqual(nodestr, nodestrexpt)
 
     def test_cmp_equal(self):
@@ -73,14 +73,14 @@ class TestNodeMethods(unittest.TestCase):
         record2 = Record("Carl Friedrich Gauss", "Universitaet Helmstedt", 1799, 18231)
         node1 = Node(self.record, set(), set())
         node2 = Node(record2, set(), set())
-        self.assert_(node1 == node2)
+        self.assertTrue(node1 == node2)
 
     def test_cmp_unequal(self):
         """Test comparison method for Nodes with different records."""
         record2 = Record("Leonhard Euler", "Universitaet Basel", 1726, 38586)
         node1 = Node(self.record, set(), set())
         node2 = Node(record2, set(), set())
-        self.assert_(node1 < node2)
+        self.assertTrue(node1 < node2)
 
     def test_add_ancestor(self):
         """Test the add_ancestor() method."""

--- a/tests/geneagrapher/test_record_methods.py
+++ b/tests/geneagrapher/test_record_methods.py
@@ -8,8 +8,7 @@ class TestRecordMethods(unittest.TestCase):
 
     def setUp(self):
         self.record = Record(
-            u"Carl Friedrich Gau\xdf", u"Universit\xe4t Helmstedt", 1799, 18231
-        )
+            "Carl Friedrich Gau\xdf", "Universit\xe4t Helmstedt", 1799, 18231)
 
     def test_init(self):
         """Test the constructor."""
@@ -53,44 +52,46 @@ class TestRecordMethods(unittest.TestCase):
         """Verify two 'equal' records are compared correctly."""
         record1 = Record("Carl Friedrich Gauss", "Universitaet Helmstedt", 1799, 18231)
         record2 = Record("Carl Friedrich Gauss", "Universitaet Helmstedt", 1799, 18231)
-        self.assert_(record1 == record2)
+        self.assertTrue(record1 == record2)
 
     def test_cmp_unequal(self):
         """Verify two 'unequal' records are compared correctly."""
         record1 = Record("Carl Friedrich Gauss", "Universitaet Helmstedt", 1799, 18231)
         record2 = Record("Leonhard Euler", "Universitaet Basel", 1726, 38586)
-        self.assert_(record1 < record2)
+        self.assertTrue(record1 < record2)
 
     def test_has_institution_yes(self):
         """Verify has_institution() method returns True when the conditions are
         right."""
         record = Record("Carl Friedrich Gauss", "Universitaet Helmstedt", 1799, 18231)
         self.assert_(record.has_institution())
+        record = Record("Carl Friedrich Gauss", "Universitaet Helmstedt", 1799, 18231)
+        self.assertTrue(record.has_institution())
 
     def test_has_institution_no(self):
         """Verify has_institution() method returns False when the conditions
         are right."""
         record = Record("Carl Friedrich Gauss", None, 1799, 18231)
-        self.assert_(not record.has_institution())
+        self.assertTrue(not record.has_institution())
 
     def test_has_year_yes(self):
         """
         Verify has_year() method returns True when the conditions are right.
         """
         record = Record("Carl Friedrich Gauss", "Universitaet Helmstedt", 1799, 18231)
-        self.assert_(record.has_year())
+        self.assertTrue(record.has_year())
 
     def test_has_year_no(self):
         """
         Verify has_year() method returns False when the conditions are right.
         """
         record = Record("Carl Friedrich Gauss", "Universitaet Helmstedt", None, 18231)
-        self.assert_(not record.has_year())
+        self.assertTrue(not record.has_year())
 
     def test_unicode_full(self):
         """Test __unicode__() method for complete record."""
         recstr = self.record.__unicode__()
-        recstrexpt = u"Carl Friedrich Gau\xdf \\nUniversit\xe4t Helmstedt \
+        recstrexpt = "Carl Friedrich Gau\xdf \\nUniversit\xe4t Helmstedt \
 (1799)"
         self.assertEqual(recstr, recstrexpt)
 
@@ -98,21 +99,21 @@ class TestRecordMethods(unittest.TestCase):
         """Test __unicode__() method for record without year."""
         record = Record(self.record.name, self.record.institution, None, 18231)
         recstr = record.__unicode__()
-        recstrexpt = u"Carl Friedrich Gau\xdf \\nUniversit\xe4t Helmstedt"
+        recstrexpt = "Carl Friedrich Gau\xdf \\nUniversit\xe4t Helmstedt"
         self.assertEqual(recstr, recstrexpt)
 
     def test_unicode_no_inst(self):
         """Test __unicode__() method for record without institution."""
         record = Record(self.record.name, None, 1799, 18231)
         recstr = record.__unicode__()
-        recstrexpt = u"Carl Friedrich Gau\xdf \\n(1799)"
+        recstrexpt = "Carl Friedrich Gau\xdf \\n(1799)"
         self.assertEqual(recstr, recstrexpt)
 
     def test_unicode_no_inst_no_id(self):
         """Test __unicode__() method for record without institution or year."""
         record = Record(self.record.name, None, None, 18231)
         recstr = record.__unicode__()
-        recstrexpt = u"Carl Friedrich Gau\xdf"
+        recstrexpt = "Carl Friedrich Gau\xdf"
         self.assertEqual(recstr, recstrexpt)
 
 

--- a/tests/geneagrapher/test_record_methods.py
+++ b/tests/geneagrapher/test_record_methods.py
@@ -48,17 +48,19 @@ class TestRecordMethods(unittest.TestCase):
             "18231",
         )
 
-    def test_cmp_equal(self):
+    def test_equal(self):
         """Verify two 'equal' records are compared correctly."""
         record1 = Record("Carl Friedrich Gauss", "Universitaet Helmstedt", 1799, 18231)
         record2 = Record("Carl Friedrich Gauss", "Universitaet Helmstedt", 1799, 18231)
         self.assertTrue(record1 == record2)
 
-    def test_cmp_unequal(self):
+    def test_unequal(self):
         """Verify two 'unequal' records are compared correctly."""
         record1 = Record("Carl Friedrich Gauss", "Universitaet Helmstedt", 1799, 18231)
         record2 = Record("Leonhard Euler", "Universitaet Basel", 1726, 38586)
         self.assertTrue(record1 < record2)
+        self.assertTrue(record1 != record2)
+        self.assertTrue(record2 > record1)
 
     def test_has_institution_yes(self):
         """Verify has_institution() method returns True when the conditions are
@@ -88,31 +90,31 @@ class TestRecordMethods(unittest.TestCase):
         record = Record("Carl Friedrich Gauss", "Universitaet Helmstedt", None, 18231)
         self.assertTrue(not record.has_year())
 
-    def test_unicode_full(self):
-        """Test __unicode__() method for complete record."""
-        recstr = self.record.__unicode__()
+    def test_str_full(self):
+        """Test __str__() method for complete record."""
+        recstr = str(self.record)
         recstrexpt = "Carl Friedrich Gau\xdf \\nUniversit\xe4t Helmstedt \
 (1799)"
         self.assertEqual(recstr, recstrexpt)
 
-    def test_unicode_no_year(self):
-        """Test __unicode__() method for record without year."""
+    def test_no_year(self):
+        """Test __str__() method for record without year."""
         record = Record(self.record.name, self.record.institution, None, 18231)
-        recstr = record.__unicode__()
+        recstr = str(record)
         recstrexpt = "Carl Friedrich Gau\xdf \\nUniversit\xe4t Helmstedt"
         self.assertEqual(recstr, recstrexpt)
 
-    def test_unicode_no_inst(self):
-        """Test __unicode__() method for record without institution."""
+    def test_no_inst(self):
+        """Test __str__() method for record without institution."""
         record = Record(self.record.name, None, 1799, 18231)
-        recstr = record.__unicode__()
+        recstr = str(record)
         recstrexpt = "Carl Friedrich Gau\xdf \\n(1799)"
         self.assertEqual(recstr, recstrexpt)
 
-    def test_unicode_no_inst_no_id(self):
+    def test_no_inst_no_id(self):
         """Test __unicode__() method for record without institution or year."""
         record = Record(self.record.name, None, None, 18231)
-        recstr = record.__unicode__()
+        recstr = str(record)
         recstrexpt = "Carl Friedrich Gau\xdf"
         self.assertEqual(recstr, recstrexpt)
 

--- a/tests/geneagrapher/testdata/get_data.py
+++ b/tests/geneagrapher/testdata/get_data.py
@@ -1,4 +1,4 @@
-import urllib2
+import urllib.request, urllib.error, urllib.parse
 
 if __name__ == '__main__':
     record_ids = [7298, 7383, 10275, 12681, 15165, 17851, 17946, 18230, 18231,
@@ -11,7 +11,7 @@ if __name__ == '__main__':
     for record_id in record_ids:
         url_base = 'http://genealogy.math.ndsu.nodak.edu/id.php?id='
         url = '{0}{1}'.format(url_base, record_id)
-        print 'Getting record {}'.format(record_id)
-        page = urllib2.urlopen(url)
+        print('Getting record {}'.format(record_id))
+        page = urllib.request.urlopen(url)
         with open('{}.html'.format(record_id), 'w') as fout:
             fout.write(page.read())


### PR DESCRIPTION
Here are the patches from the Debian package of geneagrapher which port it from Python 2 to Python 3:
https://salsa.debian.org/science-team/geneagrapher/-/tree/master/debian/patches

The patches were based on aad59e9, so I took a little time to rebase them on top of the current head of the master branch.

I also added an additional patch I wrote for the Debian package which copies the test data to the build directory.

Note that a number of the tests are failing.  Most of them because the Mathematics Genealogy Project is currently down.  (Hopefully that gets fixed soon or this is all pointless!)  But there's also several related to cache lengths, e.g.:

```python
======================================================================
FAIL: test_close (tests.geneagrapher.test_cache_grabber.TestCacheGrabberMethods)
Test the close method.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/profzoom/src/geneagrapher/geneagrapher/tests/geneagrapher/test_cache_grabber.py", line 63, in test_close
    self.assertEqual(len(cache.cache), 0)
AssertionError: 2 != 0
```

Closes: #22